### PR TITLE
Can adjust depth in relationships viewer

### DIFF
--- a/src/modules/relationships.ts
+++ b/src/modules/relationships.ts
@@ -142,11 +142,9 @@ export function fetchRelationshipsForAssetId(
 ) {
   return async (dispatch: ThunkDispatch<any, void, AnyAction>) => {
     try {
-      const { relationships: relationships_ } = await doFetchRelationshipsForAssetId(
-        id,
-        depth,
-        maxDepth
-      );
+      const {
+        relationships: relationships_,
+      } = await doFetchRelationshipsForAssetId(id, depth, maxDepth);
 
       dispatch({
         type: GET_RELATIONSHIPS,

--- a/src/modules/relationships.ts
+++ b/src/modules/relationships.ts
@@ -120,13 +120,12 @@ async function doFetchRelationshipsForAssetId(
     // newRelationships is now an array of arrays (each result from the ids above). Merge into one array
     newRelationships = newRelationships.reduce((prev: any, current: any) => {
       // For each asset id we fetched relationships, add those to the list and count the number of requests
-      current.forEach((data: { relationships: any; requestCount: number }) => {
-        prev.push(data.relationships);
-        newRequestCount += data.requestCount;
+      current.relationships.forEach((relationship: any) => {
+        prev.push(relationship);
       });
+      newRequestCount += current.requestCount;
       return prev;
     }, []);
-
     relationships = Array.from(
       new Set([...relationships, ...newRelationships])
     );
@@ -137,7 +136,7 @@ async function doFetchRelationshipsForAssetId(
 
 export function fetchRelationshipsForAssetId(id: number, maxDepth: number = 1) {
   return async (dispatch: ThunkDispatch<any, void, AnyAction>) => {
-    try {
+    // try {
       // Hack because it whines about relationships being defined in upper scope. David, HELP!
       const {
         relationships: relationships_,
@@ -147,9 +146,9 @@ export function fetchRelationshipsForAssetId(id: number, maxDepth: number = 1) {
         type: GET_RELATIONSHIPS,
         payload: { items: relationships_ },
       });
-    } catch (ex) {
-      message.error('unable to retrieve relationship data');
-    }
+    // } catch (ex) {
+    //   message.error('unable to retrieve relationship data');
+    // }
   };
 }
 

--- a/src/modules/relationships.ts
+++ b/src/modules/relationships.ts
@@ -57,8 +57,8 @@ export function fetchRelationships() {
 
 async function doFetchRelationshipsForAssetId(
   id: number,
-  depth: number,
   maxDepth: number,
+  depth: number = 0,
   requestCount: number = 0
 ) {
   const { project } = sdk;
@@ -110,8 +110,8 @@ async function doFetchRelationshipsForAssetId(
       uniqueIds.map(assetId =>
         doFetchRelationshipsForAssetId(
           assetId,
-          depth + 1,
           maxDepth,
+          depth + 1,
           requestCount
         )
       )
@@ -137,7 +137,6 @@ async function doFetchRelationshipsForAssetId(
 
 export function fetchRelationshipsForAssetId(
   id: number,
-  depth: number = 0,
   maxDepth: number = 1
 ) {
   return async (dispatch: ThunkDispatch<any, void, AnyAction>) => {
@@ -145,7 +144,7 @@ export function fetchRelationshipsForAssetId(
       // Hack because it whines about relationships being defined in upper scope. David, HELP!
       const {
         relationships: relationships_,
-      } = await doFetchRelationshipsForAssetId(id, depth, maxDepth);
+      } = await doFetchRelationshipsForAssetId(id, maxDepth);
 
       dispatch({
         type: GET_RELATIONSHIPS,

--- a/src/modules/relationships.ts
+++ b/src/modules/relationships.ts
@@ -142,6 +142,7 @@ export function fetchRelationshipsForAssetId(
 ) {
   return async (dispatch: ThunkDispatch<any, void, AnyAction>) => {
     try {
+      // Hack because it whines about relationships being defined in upper scope. David, HELP!
       const {
         relationships: relationships_,
       } = await doFetchRelationshipsForAssetId(id, depth, maxDepth);

--- a/src/modules/relationships.ts
+++ b/src/modules/relationships.ts
@@ -135,10 +135,7 @@ async function doFetchRelationshipsForAssetId(
   return { relationships, requestCount: newRequestCount };
 }
 
-export function fetchRelationshipsForAssetId(
-  id: number,
-  maxDepth: number = 1
-) {
+export function fetchRelationshipsForAssetId(id: number, maxDepth: number = 1) {
   return async (dispatch: ThunkDispatch<any, void, AnyAction>) => {
     try {
       // Hack because it whines about relationships being defined in upper scope. David, HELP!


### PR DESCRIPTION
This PR is not finished as relationships is currently down `upstream request timeout` in prod, so won't continue testing. But the principle is there.

I couldn't figure out how to deal with the `relationships` is already defined in upper scope (because the file is named `relationships` I think?), help me out here @dlcognite :D 

Also, I haven't used this `maxDepth` parameter from the GUI side (should be a setting). It does cap the number of requests (that might be why relationships is down, because at first I didn't).